### PR TITLE
Fix broken link

### DIFF
--- a/linux_paw_node_install.sh
+++ b/linux_paw_node_install.sh
@@ -5,7 +5,7 @@ command -v curl >/dev/null 2>&1 || { echo "Requires curl but it's not installed.
 command -v jq >/dev/null 2>&1 || { echo "Requires jq but it's not installed. If Ubuntu use apt-get install jq" >&2; exit 1; }
 
 #Install paw_node
-curl -s -L https://github.com/paw-digital/paw-node/releases/latest/download/linux-paw_node > /usr/local/bin/paw_node
+curl -s -L https://github.com/paw-digital/paw-node/releases/download/v1/linux-paw_node > /usr/local/bin/paw_node
 chmod +x /usr/local/bin/paw_node
 echo "Paw Node installed /usr/local/bin/paw_node"
 

--- a/mac_paw_node_install.sh
+++ b/mac_paw_node_install.sh
@@ -5,7 +5,7 @@ command -v curl >/dev/null 2>&1 || { echo "Requires curl but it's not installed.
 command -v jq >/dev/null 2>&1 || { echo "Requires jq but it's not installed. Use brew install jq" >&2; exit 1; }
 
 #Install paw_node
-curl -s -L https://github.com/paw-digital/paw-node/releases/latest/download/mac-paw_node > /usr/local/bin/paw_node
+curl -s -L https://github.com/paw-digital/paw-node/releases/download/v1/mac-paw_node > /usr/local/bin/paw_node
 chmod +x /usr/local/bin/paw_node
 echo "Paw Node installed /usr/local/bin/paw_node"
 


### PR DESCRIPTION
The download link was not working in the script, because the v1.2 only have `paw_node` and the `linux-paw_node` and `mac-paw_node` only exists in the v1, so I changed the link.